### PR TITLE
Modernize profile styling

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,15 +1,14 @@
-import * as React from "react"
-import { Link } from "gatsby"
-import "../styles/global.css"
-import "../styles/prism-theme.css"
+import * as React from "react";
+import { Link } from "gatsby";
+import { profile } from "../data/profile";
+import "../styles/global.css";
+import "../styles/prism-theme.css";
 
 const Layout = ({ children }) => {
   return (
     <div className="min-h-screen flex flex-col">
-      <main className="flex-grow">
-        {children}
-      </main>
-      
+      <main className="flex-grow">{children}</main>
+
       <footer className="bg-gray-50 border-t border-gray-200">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 py-8">
           <div className="flex flex-col md:flex-row justify-between items-center">
@@ -19,9 +18,9 @@ const Layout = ({ children }) => {
             <div className="mt-4 md:mt-0">
               <ul className="flex space-x-4">
                 <li>
-                  <a 
-                    href="https://github.com" 
-                    target="_blank" 
+                  <a
+                    href={profile.github}
+                    target="_blank"
                     rel="noopener noreferrer"
                     className="text-gray-500 hover:text-primary-600"
                   >
@@ -29,9 +28,9 @@ const Layout = ({ children }) => {
                   </a>
                 </li>
                 <li>
-                  <a 
-                    href="https://linkedin.com" 
-                    target="_blank" 
+                  <a
+                    href={profile.linkedin}
+                    target="_blank"
                     rel="noopener noreferrer"
                     className="text-gray-500 hover:text-primary-600"
                   >
@@ -44,7 +43,7 @@ const Layout = ({ children }) => {
         </div>
       </footer>
     </div>
-  )
-}
+  );
+};
 
-export default Layout 
+export default Layout;

--- a/src/data/profile.js
+++ b/src/data/profile.js
@@ -3,8 +3,10 @@ export const profile = {
   email: "leonwu127@gmail.com",
   phone: "+447784369154",
   title: "Senior Software Developer",
-  description: `I am a passionate Senior Software Developer highly skilled in backend technologies 
+  github: "https://github.com/leonwu127",
+  linkedin: "https://www.linkedin.com/in/zhiqingwu/",
+  description: `I am a passionate Senior Software Developer highly skilled in backend technologies
   and Agile methodologies, very professional in game system development, Web 3 and Fintech.
-  In my current job, I am working closely with management and business leaders, sharing knowledge 
-  and delivering high quality backend services (SLA targeting 99.99%).`
-}; 
+  In my current job, I am working closely with management and business leaders, sharing knowledge
+  and delivering high quality backend services (SLA targeting 99.99%).`,
+};

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,12 +1,12 @@
-import React, { useState } from 'react';
-import { motion } from 'framer-motion';
-import { FaGithub, FaLinkedin, FaEnvelope, FaPhone } from 'react-icons/fa';
+import React, { useState } from "react";
+import { motion } from "framer-motion";
+import { FaGithub, FaLinkedin, FaEnvelope, FaPhone } from "react-icons/fa";
 import Layout from "../components/layout";
-import { profile } from '../data/profile';
-import { experiences } from '../data/experience';
-import { skills } from '../data/skills';
-import { education } from '../data/education';
-import { interests } from '../data/interests';
+import { profile } from "../data/profile";
+import { experiences } from "../data/experience";
+import { skills } from "../data/skills";
+import { education } from "../data/education";
+import { interests } from "../data/interests";
 
 const Portfolio = () => {
   const [activeSection, setActiveSection] = useState(null);
@@ -15,17 +15,41 @@ const Portfolio = () => {
     <Layout>
       <div className="min-h-screen bg-gray-50">
         {/* Header Section */}
-        <header className="bg-white shadow-lg">
-          <div className="container mx-auto px-4 py-8">
-            <h1 className="text-4xl font-bold text-gray-800">{profile.name}</h1>
-            <div className="flex items-center space-x-4 mt-4">
-              <a href={`mailto:${profile.email}`} className="flex items-center text-gray-600 hover:text-gray-800">
-                <FaEnvelope className="mr-2" />
-                <span>{profile.email}</span>
+        <header className="bg-gradient-to-r from-primary-600 via-purple-600 to-pink-600 text-white shadow-lg">
+          <div className="container mx-auto px-4 py-16 text-center">
+            <motion.h1
+              initial={{ opacity: 0, y: -20 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="text-5xl font-extrabold tracking-tight"
+            >
+              {profile.name}
+            </motion.h1>
+            <p className="mt-2 text-xl font-medium">{profile.title}</p>
+            <div className="flex justify-center space-x-6 mt-6">
+              <a
+                href={profile.github}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-gray-200"
+              >
+                <FaGithub size={24} />
               </a>
-              <a href={`tel:${profile.phone}`} className="flex items-center text-gray-600 hover:text-gray-800">
-                <FaPhone className="mr-2" />
-                <span>{profile.phone}</span>
+              <a
+                href={profile.linkedin}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-gray-200"
+              >
+                <FaLinkedin size={24} />
+              </a>
+              <a
+                href={`mailto:${profile.email}`}
+                className="hover:text-gray-200"
+              >
+                <FaEnvelope size={24} />
+              </a>
+              <a href={`tel:${profile.phone}`} className="hover:text-gray-200">
+                <FaPhone size={24} />
               </a>
             </div>
           </div>
@@ -62,16 +86,20 @@ const Portfolio = () => {
                     <p className="text-lg font-semibold mt-2">{exp.role}</p>
                   </div>
                   <button
-                    onClick={() => setActiveSection(activeSection === index ? null : index)}
+                    onClick={() =>
+                      setActiveSection(activeSection === index ? null : index)
+                    }
                     className="text-blue-600 hover:text-blue-800"
                   >
-                    {activeSection === index ? 'Show Less' : 'Show More'}
+                    {activeSection === index ? "Show Less" : "Show More"}
                   </button>
                 </div>
                 {activeSection === index && (
                   <ul className="mt-4 space-y-2">
                     {exp.details.map((detail, i) => (
-                      <li key={i} className="text-gray-700">{detail}</li>
+                      <li key={i} className="text-gray-700">
+                        {detail}
+                      </li>
                     ))}
                   </ul>
                 )}
@@ -92,7 +120,9 @@ const Portfolio = () => {
               >
                 <h3 className="text-xl font-bold">{edu.degree}</h3>
                 <p className="text-gray-600">{edu.school}</p>
-                <p className="text-gray-700 mt-2">{edu.grade} ({edu.period})</p>
+                <p className="text-gray-700 mt-2">
+                  {edu.grade} ({edu.period})
+                </p>
               </motion.div>
             ))}
           </div>
@@ -129,7 +159,9 @@ const Portfolio = () => {
                 whileHover={{ scale: 1.02 }}
                 className="bg-white rounded-lg shadow-lg p-6"
               >
-                <h3 className="text-xl font-bold mb-4 capitalize">{category}</h3>
+                <h3 className="text-xl font-bold mb-4 capitalize">
+                  {category}
+                </h3>
                 <ul className="list-disc list-inside text-gray-700">
                   {items.map((item, index) => (
                     <li key={index}>{item}</li>
@@ -146,4 +178,4 @@ const Portfolio = () => {
 
 export default Portfolio;
 
-export const Head = () => <title>Zhiqing Wu - Portfolio</title> 
+export const Head = () => <title>Zhiqing Wu - Portfolio</title>;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,10 +1,12 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
   body {
-    @apply bg-gray-50 text-gray-900;
+    @apply bg-gray-50 text-gray-900 font-sans;
   }
   h1 {
     @apply text-4xl font-bold mb-4 text-gray-800;
@@ -59,4 +61,4 @@
 
 ::-webkit-scrollbar-thumb:hover {
   background: #555;
-} 
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,29 +6,32 @@ module.exports = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ["Inter", "ui-sans-serif", "system-ui", "sans-serif"],
+      },
       colors: {
         primary: {
-          50: '#f0f9ff',
-          100: '#e0f2fe',
-          200: '#bae6fd',
-          300: '#7dd3fc',
-          400: '#38bdf8',
-          500: '#0ea5e9',
-          600: '#0284c7',
-          700: '#0369a1',
-          800: '#075985',
-          900: '#0c4a6e',
-          950: '#082f49',
+          50: "#f0f9ff",
+          100: "#e0f2fe",
+          200: "#bae6fd",
+          300: "#7dd3fc",
+          400: "#38bdf8",
+          500: "#0ea5e9",
+          600: "#0284c7",
+          700: "#0369a1",
+          800: "#075985",
+          900: "#0c4a6e",
+          950: "#082f49",
         },
       },
       typography: {
         DEFAULT: {
           css: {
-            maxWidth: '65ch',
+            maxWidth: "65ch",
             a: {
-              textDecoration: 'none',
-              '&:hover': {
-                textDecoration: 'underline',
+              textDecoration: "none",
+              "&:hover": {
+                textDecoration: "underline",
               },
             },
           },
@@ -40,4 +43,4 @@ module.exports = {
     // We'll add this back after installing the package
     // require('@tailwindcss/typography'),
   ],
-} 
+};


### PR DESCRIPTION
## Summary
- add GitHub/LinkedIn links to profile data
- import profile links in layout and use them in footer
- apply new "Inter" font and font-sans utility globally
- extend Tailwind config with `Inter` font family
- redesign portfolio header with gradient background and icon links

## Testing
- `npx prettier --write src/components/layout.js src/data/profile.js src/pages/index.js src/styles/global.css tailwind.config.js`
- `npm run build` *(fails: gatsby not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460aa989308331bcc6ec823cb857fe